### PR TITLE
FIX: preload topic custom fields

### DIFF
--- a/app/serializers/concerns/case_mixin.rb
+++ b/app/serializers/concerns/case_mixin.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module CaseMixin
+  HAS_SALESFORCE_CASE ||= "has_salesforce_case"
+
   def self.included(klass)
     klass.attributes :has_salesforce_case
   end

--- a/app/serializers/concerns/case_mixin.rb
+++ b/app/serializers/concerns/case_mixin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CaseMixin
-  HAS_SALESFORCE_CASE ||= "has_salesforce_case"
+  HAS_SALESFORCE_CASE = "has_salesforce_case"
 
   def self.included(klass)
     klass.attributes :has_salesforce_case

--- a/plugin.rb
+++ b/plugin.rb
@@ -79,6 +79,8 @@ after_initialize do
 
   allow_staff_user_custom_field(::Salesforce::Person::CONTACT_ID_FIELD)
   allow_staff_user_custom_field(::Salesforce::Person::LEAD_ID_FIELD)
+  register_topic_custom_field_type(::CaseMixin::HAS_SALESFORCE_CASE, :boolean)
+  CategoryList.preloaded_topic_custom_fields << ::CaseMixin::HAS_SALESFORCE_CASE
 
   on(:post_created) do |post, opts|
     topic = post.topic


### PR DESCRIPTION
Visiting the `/c` route when the plugin is enabled results in 
```
HasCustomFields::NotPreloadedError in CategoriesController#index
```

Preloading the `has_salesforce_case` custom field fixes the issue.