### PR TITLE
FIX: remove unused admin route

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -69,8 +69,6 @@ after_initialize do
     get "/admin/authorize" => "admin#authorize"
   end
 
-  add_admin_route 'salesforce.title', 'salesforce'
-
   Discourse::Application.routes.append do
     mount ::Salesforce::Engine, at: "salesforce"
   end


### PR DESCRIPTION
This was breaking the frontend when visiting /admin/plugins