### PR TITLE
FEATURE: sync Salesforce lead/contact on user account creation.

### DIFF
--- a/app/controllers/salesforce/persons_controller.rb
+++ b/app/controllers/salesforce/persons_controller.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 
-class Salesforce::PersonsController < Admin::AdminController
-  before_action :find_user
-  attr_accessor :user
+module Salesforce
+  class PersonsController < ::Admin::AdminController
+    before_action :find_user
+    attr_accessor :user
 
-  def create
-    begin
-      type = params.require(:type)
-      if type == "lead"
-        Salesforce::Lead.create!(user)
-      elsif type == "contact"
-        Salesforce::Contact.create!(user)
+    def create
+      type = params.require(:type).capitalize
+      raise ArgumentError.new :type if [Lead::OBJECT_NAME, Contact::OBJECT_NAME].exclude?(type)
+
+      begin
+        "::Salesforce::#{type}".constantize.create!(user)
+        render json: success_json
+      rescue => e
+        render json: { errors: [e.message] }, status: 422
       end
-      render json: success_json
-    rescue => e
-      render json: { errors: [e.message] }, status: 422
     end
-  end
 
-  def create_contact
-    begin
-      Salesforce::Contact.create!(user)
-      render json: success_json
-    rescue => e
-      render json: { errors: [e.message] }, status: 422
+    def create_contact
+      begin
+        Contact.create!(user)
+        render json: success_json
+      rescue => e
+        render json: { errors: [e.message] }, status: 422
+      end
     end
-  end
 
-  def find_user
-    params.require(:user_id)
-    user_id = params[:user_id]
-    @user = User.find_by(id: user_id)
-    raise Discourse::InvalidParameters.new(:user_id) if user.blank?
+    def find_user
+      params.require(:user_id)
+      user_id = params[:user_id]
+      @user = User.find_by(id: user_id)
+      raise Discourse::InvalidParameters.new(:user_id) if user.blank?
+    end
   end
 end

--- a/app/controllers/salesforce/persons_controller.rb
+++ b/app/controllers/salesforce/persons_controller.rb
@@ -6,7 +6,12 @@ class Salesforce::PersonsController < Admin::AdminController
 
   def create
     begin
-      Salesforce::Person.create!(params.require(:type), user)
+      type = params.require(:type)
+      if type == "lead"
+        Salesforce::Lead.create!(user)
+      elsif type == "contact"
+        Salesforce::Contact.create!(user)
+      end
       render json: success_json
     rescue => e
       render json: { errors: [e.message] }, status: 422

--- a/app/jobs/scheduled/sync_salesforce_users.rb
+++ b/app/jobs/scheduled/sync_salesforce_users.rb
@@ -9,7 +9,7 @@ module ::Jobs
       return unless SiteSetting.salesforce_enabled
 
       api_client = Salesforce::Api.new
-      lead_fields = UserCustomField.where(name: ::Salesforce::Person::LEAD_ID_FIELD)
+      lead_fields = UserCustomField.where(name: ::Salesforce::Lead::ID_FIELD)
       lead_fields.find_in_batches(batch_size: 100) do |fields|
         ids = fields.pluck(:value)
         begin
@@ -19,14 +19,14 @@ module ::Jobs
             next if contact_id.blank?
 
             field = lead_fields.find_by(value: lead["Id"])
-            field.update(name: ::Salesforce::Person::CONTACT_ID_FIELD, value: contact_id)
+            field.update(name: ::Salesforce::Contact::ID_FIELD, value: contact_id)
           end
         rescue => e
           Discourse.warn_exception(e, message: "Failed to sync Salesforce leads")
         end
       end
 
-      contact_fields = UserCustomField.where(name: ::Salesforce::Person::CONTACT_ID_FIELD)
+      contact_fields = UserCustomField.where(name: ::Salesforce::Contact::ID_FIELD)
       contact_fields.find_in_batches(batch_size: 100) do |fields|
         ids = fields.pluck(:value)
         begin

--- a/app/models/salesforce/contact.rb
+++ b/app/models/salesforce/contact.rb
@@ -10,7 +10,7 @@ module ::Salesforce
       Salesforce.contacts_group
     end
 
-    def self.payload
+    def self.payload(user)
       user.salesforce_contact_payload
     end
   end

--- a/app/models/salesforce/contact.rb
+++ b/app/models/salesforce/contact.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ::Salesforce
+  class Contact < Person
+    ID_FIELD = "salesforce_contact_id"
+    SOURCE = "Web"
+    OBJECT_NAME = "Contact"
+
+    def self.group
+      Salesforce.contacts_group
+    end
+
+    def self.payload
+      user.salesforce_contact_payload
+    end
+  end
+end

--- a/app/models/salesforce/lead.rb
+++ b/app/models/salesforce/lead.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ::Salesforce
+  class Lead < Person
+    ID_FIELD = "salesforce_lead_id"
+    DEFAULT_COMPANY_NAME = "None"
+    OBJECT_NAME = "Lead"
+
+    def self.group
+      Salesforce.leads_group
+    end
+
+    def self.payload
+      user.salesforce_lead_payload
+    end
+  end
+end

--- a/app/models/salesforce/lead.rb
+++ b/app/models/salesforce/lead.rb
@@ -10,7 +10,7 @@ module ::Salesforce
       Salesforce.leads_group
     end
 
-    def self.payload
+    def self.payload(user)
       user.salesforce_lead_payload
     end
   end

--- a/app/models/salesforce/person.rb
+++ b/app/models/salesforce/person.rb
@@ -8,7 +8,7 @@ module ::Salesforce
     def self.create!(user)
       return if user.custom_fields[self::ID_FIELD].present?
 
-      data = Salesforce::Api.new.post("sobjects/#{self::OBJECT_NAME}", payload)
+      data = Salesforce::Api.new.post("sobjects/#{self::OBJECT_NAME}", payload(user))
       id = data["id"]
 
       user.custom_fields[self::ID_FIELD] = id
@@ -29,7 +29,7 @@ module ::Salesforce
       not_implemented
     end
 
-    def self.payload
+    def self.payload(user)
       not_implemented
     end
 

--- a/db/fixtures/001_groups.rb
+++ b/db/fixtures/001_groups.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
 if Salesforce.leads_group.blank?
-  group = Group.create!(
-    name: 'salesforce-leads',
-    visibility_level: Group.visibility_levels[:staff],
-    primary_group: true,
-    title: 'Lead',
-    flair_icon: 'fab-salesforce',
-    bio_raw: 'Members are automatically synced from Salesforce via API',
-    full_name: 'Salesforce Leads'
-  )
+  group = Group.where(name: 'salesforce-leads')
+    .first_or_create!(
+      name: 'salesforce-leads',
+      visibility_level: Group.visibility_levels[:staff],
+      primary_group: true,
+      title: 'Lead',
+      flair_icon: 'fab-salesforce',
+      bio_raw: 'Members are automatically synced from Salesforce via API',
+      full_name: 'Salesforce Leads'
+    )
   SiteSetting.salesforce_leads_group_id = group.id
 end
 
 if Salesforce.contacts_group.blank?
-  group = Group.create!(
-    name: 'salesforce-contacts',
-    visibility_level: Group.visibility_levels[:staff],
-    primary_group: true,
-    title: 'Contact',
-    flair_icon: 'fab-salesforce',
-    bio_raw: 'Members are automatically synced from Salesforce via API',
-    full_name: 'Salesforce Contacts'
-  )
+  group = Group.where(name: 'salesforce-contacts')
+    .first_or_create!(
+      name: 'salesforce-contacts',
+      visibility_level: Group.visibility_levels[:staff],
+      primary_group: true,
+      title: 'Contact',
+      flair_icon: 'fab-salesforce',
+      bio_raw: 'Members are automatically synced from Salesforce via API',
+      full_name: 'Salesforce Contacts'
+    )
   SiteSetting.salesforce_contacts_group_id = group.id
 end

--- a/lib/salesforce/api.rb
+++ b/lib/salesforce/api.rb
@@ -25,6 +25,11 @@ module ::Salesforce
       @prefix = "/services/data/v#{VERSION}"
     end
 
+    def query(soql)
+      soql = URI::Parser.new.escape(soql.gsub(" ", "+"))
+      get("query/?q=#{soql}")
+    end
+
     def get(path)
       call(path) do |uri|
         faraday.get(uri)

--- a/spec/jobs/create_feed_item_spec.rb
+++ b/spec/jobs/create_feed_item_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Jobs::CreateFeedItem do
     post.custom_fields[::Salesforce::FeedItem::ID_FIELD] = "feed_123"
     post.save_custom_fields
 
-    user.custom_fields[::Salesforce::Person::LEAD_ID_FIELD] = "lead_123"
+    user.salesforce_lead_id = "lead_123"
     user.save_custom_fields
 
     ::Salesforce::FeedItem.any_instance.expects(:create!).never
@@ -26,7 +26,7 @@ RSpec.describe Jobs::CreateFeedItem do
   end
 
   it 'creates a feed item on Salesforce lead object' do
-    user.custom_fields[::Salesforce::Person::LEAD_ID_FIELD] = "lead_123"
+    user.salesforce_lead_id = "lead_123"
     user.save_custom_fields
 
     ::Salesforce::FeedItem.any_instance.expects(:create!).once

--- a/spec/jobs/sync_salesforce_users_spec.rb
+++ b/spec/jobs/sync_salesforce_users_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Jobs::SyncSalesforceUsers do
   fab!(:user2) { Fabricate(:user) }
 
   before do
-    user1.custom_fields[::Salesforce::Person::LEAD_ID_FIELD] = "lead_123"
+    user1.salesforce_lead_id = "lead_123"
     user1.save!
 
-    user2.custom_fields[::Salesforce::Person::CONTACT_ID_FIELD] = "contact_123"
+    user2.salesforce_contact_id = "contact_123"
     user2.save!
 
     path = api_path.sub("sobjects", "composite/sobjects")
@@ -27,9 +27,9 @@ RSpec.describe Jobs::SyncSalesforceUsers do
     described_class.new.execute({})
 
     fields = user1.reload.custom_fields
-    expect(fields[::Salesforce::Person::LEAD_ID_FIELD]).to eq(nil)
-    expect(fields[::Salesforce::Person::CONTACT_ID_FIELD]).to eq("contact_456")
+    expect(fields[::Salesforce::Lead::ID_FIELD]).to eq(nil)
+    expect(fields[::Salesforce::Contact::ID_FIELD]).to eq("contact_456")
 
-    expect(user2.reload.custom_fields[::Salesforce::Person::CONTACT_ID_FIELD]).to eq("contact_789")
+    expect(user2.reload.salesforce_contact_id).to eq("contact_789")
   end
 end

--- a/spec/models/feed_item_spec.rb
+++ b/spec/models/feed_item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Salesforce::FeedItem do
 
   describe '#create!' do
     it 'creates a feed item on Salesforce lead object' do
-      user.custom_fields[::Salesforce::Person::LEAD_ID_FIELD] = "lead_123"
+      user.salesforce_lead_id = "lead_123"
       user.save!
 
       feed_item = ::Salesforce::FeedItem.new(user.salesforce_lead_id, post)

--- a/spec/requests/persons_controller_spec.rb
+++ b/spec/requests/persons_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ::Salesforce::PersonsController do
       }
 
       expect(response.status).to eq(200)
-      expect(user.custom_fields[::Salesforce::Person::CONTACT_ID_FIELD]).to eq("123456")
+      expect(user.salesforce_contact_id).to eq("123456")
     end
 
     it 'creates a new lead object in Salesforce' do
@@ -39,7 +39,7 @@ RSpec.describe ::Salesforce::PersonsController do
       }
 
       expect(response.status).to eq(200)
-      expect(user.custom_fields[::Salesforce::Person::LEAD_ID_FIELD]).to eq("123456")
+      expect(user.salesforce_lead_id).to eq("123456")
     end
   end
 end


### PR DESCRIPTION
When a new user join on Discourse it will check Salesforce for any existing lead/contact object. Then it will update the object id in user custom field if available.

Also did some code refactoring.