### PR TITLE
FEATURE: add new site setting to change authorization server's url.

### DIFF
--- a/app/controllers/salesforce/admin_controller.rb
+++ b/app/controllers/salesforce/admin_controller.rb
@@ -5,7 +5,7 @@ module Salesforce
     skip_before_action :check_xhr, :preload_json
 
     def authorize
-      redirect_to "https://login.salesforce.com/services/oauth2/authorize?client_id=#{SiteSetting.salesforce_client_id}&redirect_uri=#{Discourse.base_url}&response_type=code"
+      redirect_to "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/authorize?client_id=#{SiteSetting.salesforce_client_id}&redirect_uri=#{Discourse.base_url}&response_type=code"
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,9 +4,10 @@ en:
     salesforce_login_enabled: 'Enable Salesforce Social Login'
     salesforce_client_id: "Salesforce connected app's client id"
     salesforce_client_secret: "Salesforce connected app's client secret"
+    salesforce_rsa_private_key: "Salesforce connected app's RSA private key"
+    salesforce_authorization_server_url: "Salesforce authorization server's URL"
     salesforce_username: "Salesforce account username"
     salesforce_max_feed_items_per_day: "Maximum number topic replies which can be posted as feed items on Salesforce objects (Case/Lead/Contact) per day"
-    salesforce_rsa_private_key: "Salesforce connected app's RSA private key"
     salesforce_case_tag_name: "Tag name to add in topics with a Salesforce case"
     salesforce_case_status_tag_enabled: "Enable to add tags based on Salesforce case status"
     salesforce_case_status_tag_prefix: "Prefix to add before Salesforce case status tags. For example, if prefix is 'case' then the tags will be added like case-open, case-closed, etc.,"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,8 @@ plugins:
   salesforce_rsa_private_key:
     default: ''
     textarea: true
+  salesforce_authorization_server_url:
+    default: 'https://login.salesforce.com'
   salesforce_username:
     default: ''
   salesforce_case_tag_name:

--- a/lib/salesforce/api.rb
+++ b/lib/salesforce/api.rb
@@ -61,7 +61,7 @@ module ::Salesforce
       AdminDashboardData.clear_problem_message(APP_NOT_APPROVED) if AdminDashboardData.problem_message_check(APP_NOT_APPROVED)
       return if access_token.present? && SiteSetting.salesforce_instance_url.present?
 
-      connection = Faraday.new(url: 'https://login.salesforce.com')
+      connection = Faraday.new(url: SiteSetting.salesforce_authorization_server_url)
       response = connection.post("/services/oauth2/token") do |req|
         req.body = URI.encode_www_form({
           grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
@@ -88,7 +88,7 @@ module ::Salesforce
       {
         iss: SiteSetting.salesforce_client_id,
         sub: SiteSetting.salesforce_username,
-        aud: "https://login.salesforce.com",
+        aud: SiteSetting.salesforce_authorization_server_url,
         iat: Time.now.utc.to_i,
         exp: Time.now.utc.to_i + 180
       }

--- a/plugin.rb
+++ b/plugin.rb
@@ -208,7 +208,7 @@ after_initialize do
     option :name, 'salesforce'
 
     option :client_options,
-            site: 'https://login.salesforce.com',
+            site: SiteSetting.salesforce_authorization_server_url,
             authorize_url: '/services/oauth2/authorize',
             token_url: '/services/oauth2/token'
   end


### PR DESCRIPTION
Salesforce has sandbox mode where they will use different authorization server URL. Previosuly, we didn't had an option to change it.