### PR TITLE
DEV: Do not seed groups in test environment

### DIFF
--- a/db/fixtures/001_groups.rb
+++ b/db/fixtures/001_groups.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-if Salesforce.leads_group.blank?
-  group = Group.where(name: 'salesforce-leads')
-    .first_or_create!(
-      name: 'salesforce-leads',
-      visibility_level: Group.visibility_levels[:staff],
-      primary_group: true,
-      title: 'Lead',
-      flair_icon: 'fab-salesforce',
-      bio_raw: 'Members are automatically synced from Salesforce via API',
-      full_name: 'Salesforce Leads'
-    )
-  SiteSetting.salesforce_leads_group_id = group.id
-end
+if !Rails.env.test?
+  if Salesforce.leads_group.blank?
+    group = Group.where(name: 'salesforce-leads')
+      .first_or_create!(
+        name: 'salesforce-leads',
+        visibility_level: Group.visibility_levels[:staff],
+        primary_group: true,
+        title: 'Lead',
+        flair_icon: 'fab-salesforce',
+        bio_raw: 'Members are automatically synced from Salesforce via API',
+        full_name: 'Salesforce Leads'
+      )
+    SiteSetting.salesforce_leads_group_id = group.id
+  end
 
-if Salesforce.contacts_group.blank?
-  group = Group.where(name: 'salesforce-contacts')
-    .first_or_create!(
-      name: 'salesforce-contacts',
-      visibility_level: Group.visibility_levels[:staff],
-      primary_group: true,
-      title: 'Contact',
-      flair_icon: 'fab-salesforce',
-      bio_raw: 'Members are automatically synced from Salesforce via API',
-      full_name: 'Salesforce Contacts'
-    )
-  SiteSetting.salesforce_contacts_group_id = group.id
+  if Salesforce.contacts_group.blank?
+    group = Group.where(name: 'salesforce-contacts')
+      .first_or_create!(
+        name: 'salesforce-contacts',
+        visibility_level: Group.visibility_levels[:staff],
+        primary_group: true,
+        title: 'Contact',
+        flair_icon: 'fab-salesforce',
+        bio_raw: 'Members are automatically synced from Salesforce via API',
+        full_name: 'Salesforce Contacts'
+      )
+    SiteSetting.salesforce_contacts_group_id = group.id
+  end
 end


### PR DESCRIPTION
### What is this change?

The seed groups in this plugin break some expectations in the core test suite about what groups are in the DB.

This change makes it so we don't seed the groups in the test environment.

### What else did we consider?

We briefly considered three approaches:

1. Do not add the seeds in test environment. (This change.)
2. Make core group tests less strict.
3. Allow plugins to add to `AUTO_GROUPS`.

The last one is promising, but potentially requires a lot of work. We're going with the first one for now since it's quick and easy.