### PR TITLE
DEV: Do not seed groups in test environment

### DIFF
--- a/db/fixtures/001_groups.rb
+++ b/db/fixtures/001_groups.rb
@@ -1,29 +1,3 @@
 # frozen_string_literal: true
 
-if Salesforce.leads_group.blank?
-  group = Group.where(name: 'salesforce-leads')
-    .first_or_create!(
-      name: 'salesforce-leads',
-      visibility_level: Group.visibility_levels[:staff],
-      primary_group: true,
-      title: 'Lead',
-      flair_icon: 'fab-salesforce',
-      bio_raw: 'Members are automatically synced from Salesforce via API',
-      full_name: 'Salesforce Leads'
-    )
-  SiteSetting.salesforce_leads_group_id = group.id
-end
-
-if Salesforce.contacts_group.blank?
-  group = Group.where(name: 'salesforce-contacts')
-    .first_or_create!(
-      name: 'salesforce-contacts',
-      visibility_level: Group.visibility_levels[:staff],
-      primary_group: true,
-      title: 'Contact',
-      flair_icon: 'fab-salesforce',
-      bio_raw: 'Members are automatically synced from Salesforce via API',
-      full_name: 'Salesforce Contacts'
-    )
-  SiteSetting.salesforce_contacts_group_id = group.id
-end
+Salesforce.seed_groups! unless Rails.env.test?

--- a/plugin.rb
+++ b/plugin.rb
@@ -65,7 +65,7 @@ after_initialize do
           )
         SiteSetting.salesforce_leads_group_id = group.id
       end
-      
+
       if contacts_group.blank?
         group = Group.where(name: 'salesforce-contacts')
           .first_or_create!(

--- a/plugin.rb
+++ b/plugin.rb
@@ -50,6 +50,36 @@ after_initialize do
 
       Group.find_by(id: group_id)
     end
+
+    def self.seed_groups!
+      if leads_group.blank?
+        group = Group.where(name: 'salesforce-leads')
+          .first_or_create!(
+            name: 'salesforce-leads',
+            visibility_level: Group.visibility_levels[:staff],
+            primary_group: true,
+            title: 'Lead',
+            flair_icon: 'fab-salesforce',
+            bio_raw: 'Members are automatically synced from Salesforce via API',
+            full_name: 'Salesforce Leads'
+          )
+        SiteSetting.salesforce_leads_group_id = group.id
+      end
+      
+      if contacts_group.blank?
+        group = Group.where(name: 'salesforce-contacts')
+          .first_or_create!(
+            name: 'salesforce-contacts',
+            visibility_level: Group.visibility_levels[:staff],
+            primary_group: true,
+            title: 'Contact',
+            flair_icon: 'fab-salesforce',
+            bio_raw: 'Members are automatically synced from Salesforce via API',
+            full_name: 'Salesforce Contacts'
+          )
+        SiteSetting.salesforce_contacts_group_id = group.id
+      end
+    end
   end
 
   [

--- a/spec/requests/cases_controller_spec.rb
+++ b/spec/requests/cases_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ::Salesforce::CasesController do
 
     it 'creates a new case object in Salesforce' do
       sign_in(admin)
+      Salesforce.seed_groups!
 
       stub_request(:post, "#{api_path}/Contact").
         with(body: topic.user.salesforce_contact_payload.to_json).

--- a/spec/requests/persons_controller_spec.rb
+++ b/spec/requests/persons_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ::Salesforce::PersonsController do
   describe "#create" do
     before do
       sign_in(admin)
+      Salesforce.seed_groups!
     end
 
     it 'creates a new contact object in Salesforce' do


### PR DESCRIPTION
Co-authored-by: Ted Johansson <drenmi@gmail.com>

### What is this change?

The seed groups in this plugin break some expectations in the core test suite about what groups are in the DB.

This change makes it so we don't seed the groups in the test environment.

### What else did we consider?

We briefly considered three approaches:

Do not add the seeds in test environment. (This change.) Make core group tests less strict.
Allow plugins to add to `AUTO_GROUPS`.
The last one is promising, but potentially requires a lot of work. We're going with the first one for now since it's quick and easy.

Mostly copied from the PR https://github.com/discourse/discourse-salesforce/pull/37