### PR TITLE
UX: Drop unneeded comma in a string

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,7 +10,7 @@ en:
     salesforce_max_feed_items_per_day: "Maximum number topic replies which can be posted as feed items on Salesforce objects (Case/Lead/Contact) per day"
     salesforce_case_tag_name: "Tag name to add in topics with a Salesforce case"
     salesforce_case_status_tag_enabled: "Enable to add tags based on Salesforce case status"
-    salesforce_case_status_tag_prefix: "Prefix to add before Salesforce case status tags. For example, if prefix is 'case' then the tags will be added like case-open, case-closed, etc.,"
+    salesforce_case_status_tag_prefix: "Prefix to add before Salesforce case status tags. For example, if prefix is 'case' then the tags will be added like case-open, case-closed, etc."
     errors:
       salesforce_client_credentials_required: "Salesforce client id and client secret settings are required"
   salesforce:


### PR DESCRIPTION
It's in plugin settings:

<img width="757" alt="Screenshot 2023-03-01 at 16 39 22" src="https://user-images.githubusercontent.com/1274517/222141916-faa9275a-2a97-4afa-8909-a61123d7f998.png">
