### PR TITLE
FEATURE: Optionally skip contact creation on case sync

### DIFF
--- a/app/models/salesforce/case.rb
+++ b/app/models/salesforce/case.rb
@@ -57,7 +57,12 @@ module ::Salesforce
         if c.new_record?
           post = topic.first_post
           description = "#{post.full_url}\n\n#{post.raw}"
-          c.contact_id = user.salesforce_contact_id || user.create_salesforce_contact
+          c.contact_id = user.salesforce_contact_id
+
+          if c.contact_id.blank? && !SiteSetting.salesforce_skip_contact_creation_on_case_sync
+            c.contact_id = user.create_salesforce_contact
+          end
+
           c.subject = topic.title
           c.description = description
           c.generate!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,7 @@ en:
     salesforce_case_tag_name: "Tag name to add in topics with a Salesforce case"
     salesforce_case_status_tag_enabled: "Enable to add tags based on Salesforce case status"
     salesforce_case_status_tag_prefix: "Prefix to add before Salesforce case status tags. For example, if prefix is 'case' then the tags will be added like case-open, case-closed, etc."
+    salesforce_skip_contact_creation_on_case_sync: "Skip creation of Salesforce Contact during Case sync"
     errors:
       salesforce_client_credentials_required: "Salesforce client id and client secret settings are required"
   salesforce:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,3 +43,5 @@ plugins:
     default: ""
   salesforce_case_origin:
     default: 'Web'
+  salesforce_skip_contact_creation_on_case_sync:
+    default: false

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../spec_helper"
+
+RSpec.describe Salesforce::Case do
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+
+  include_context "with salesforce spec helper"
+
+  describe ".sync!" do
+    before do
+      Salesforce.seed_groups!
+
+      stub_request(:get, "#{api_path}/Case/234567").to_return(
+        status: 200,
+        body: %({"CaseNumber":"345678","Status":"New"}),
+      )
+    end
+
+    shared_examples "existing contact" do
+      it "uses the existing contact" do
+        topic.user.salesforce_contact_id = "123456"
+        topic.user.save_custom_fields
+
+        stub_request(:post, "#{api_path}/Case").with(
+          body:
+            %({"ContactId":"123456","Subject":"#{topic.title}","Description":"#{post.full_url}\\n\\n#{post.raw}","Origin":"Web"}),
+        ).to_return(status: 200, body: %({"id":"234567"}), headers: {})
+
+        expect do ::Salesforce::Case.sync!(topic) end.to change { ::Salesforce::Case.count }.by(1)
+
+        expect(topic.user.salesforce_contact_id).to eq("123456")
+      end
+    end
+
+    context "when salesforce_skip_contact_creation_on_case_sync is true" do
+      before { SiteSetting.salesforce_skip_contact_creation_on_case_sync = true }
+
+      it "does not create contact if none exist" do
+        stub_request(:post, "#{api_path}/Case").with(
+          body:
+            %({"ContactId":null,"Subject":"#{topic.title}","Description":"#{post.full_url}\\n\\n#{post.raw}","Origin":"Web"}),
+        ).to_return(status: 200, body: %({"id":"234567"}), headers: {})
+
+        expect do ::Salesforce::Case.sync!(topic) end.to change { ::Salesforce::Case.count }.by(1)
+
+        expect(topic.user.salesforce_contact_id).to be_nil
+      end
+
+      include_examples "existing contact"
+    end
+
+    context "when salesforce_skip_contact_creation_on_case_sync is false" do
+      before do
+        SiteSetting.salesforce_skip_contact_creation_on_case_sync = false
+
+        stub_request(:post, "#{api_path}/Contact").with(
+          body: topic.user.salesforce_contact_payload.to_json,
+        ).to_return(status: 200, body: %({"id":"123456"}), headers: {})
+
+        stub_request(:post, "#{api_path}/Case").with(
+          body:
+            %({"ContactId":"123456","Subject":"#{topic.title}","Description":"#{post.full_url}\\n\\n#{post.raw}","Origin":"Web"}),
+        ).to_return(status: 200, body: %({"id":"234567"}), headers: {})
+      end
+
+      it "creates a new contact if none exist" do
+        expect(topic.user.salesforce_contact_id).to be_nil
+
+        expect do ::Salesforce::Case.sync!(topic) end.to change { ::Salesforce::Case.count }.by(1)
+
+        expect(topic.user.salesforce_contact_id).to eq("123456")
+      end
+
+      include_examples "existing contact"
+    end
+  end
+end


### PR DESCRIPTION
Currently, a new Salesforce contact is created during Case sync if the topic creator isn't mapped to a Salesforce contact during case sync.

This change introduces a site setting to conditionally create and map contact during case sync.