### PR TITLE
FEATURE: Add default Contact ID for Case Sync Site Setting

### DIFF
--- a/app/models/salesforce/case.rb
+++ b/app/models/salesforce/case.rb
@@ -57,12 +57,8 @@ module ::Salesforce
         if c.new_record?
           post = topic.first_post
           description = "#{post.full_url}\n\n#{post.raw}"
-          c.contact_id = user.salesforce_contact_id
-
-          if c.contact_id.blank? && !SiteSetting.salesforce_skip_contact_creation_on_case_sync
-            c.contact_id = user.create_salesforce_contact
-          end
-
+          c.contact_id =
+            contact_id_for(user) || SiteSetting.salesforce_default_contact_id_for_case_sync.presence
           c.subject = topic.title
           c.description = description
           c.generate!
@@ -76,6 +72,16 @@ module ::Salesforce
         c.sync!
       end
       salesforce_case
+    end
+
+    def self.contact_id_for(user)
+      return user.salesforce_contact_id if user.salesforce_contact_id
+
+      if SiteSetting.salesforce_skip_contact_creation_on_case_sync
+        nil
+      else
+        user.create_salesforce_contact
+      end
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,6 +12,7 @@ en:
     salesforce_case_status_tag_enabled: "Enable to add tags based on Salesforce case status"
     salesforce_case_status_tag_prefix: "Prefix to add before Salesforce case status tags. For example, if prefix is 'case' then the tags will be added like case-open, case-closed, etc."
     salesforce_skip_contact_creation_on_case_sync: "Skip creation of Salesforce Contact during Case sync"
+    salesforce_default_contact_id_for_case_sync: "Default Salesforce Contact ID to use during Case sync. Useful when 'salesforce_skip_contact_creation_on_case_sync' is enabled."
     errors:
       salesforce_client_credentials_required: "Salesforce client id and client secret settings are required"
   salesforce:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,3 +45,5 @@ plugins:
     default: 'Web'
   salesforce_skip_contact_creation_on_case_sync:
     default: false
+  salesforce_default_contact_id_for_case_sync:
+    default: ""

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Salesforce::Case do
         expect(topic.user.salesforce_contact_id).to be_nil
       end
 
+      it "uses salesforce_default_contact_id_for_case_sync for ContactId if present" do
+        SiteSetting.salesforce_default_contact_id_for_case_sync = "4546566"
+
+        stub_request(:post, "#{api_path}/Case").with(
+          body:
+            %({"ContactId":"4546566","Subject":"#{topic.title}","Description":"#{post.full_url}\\n\\n#{post.raw}","Origin":"Web"}),
+        ).to_return(status: 200, body: %({"id":"234567"}), headers: {})
+
+        expect do ::Salesforce::Case.sync!(topic) end.to change { ::Salesforce::Case.count }.by(1)
+      end
+
       include_examples "existing contact"
     end
 


### PR DESCRIPTION
Currently, enabling `salesforce_skip_contact_creation_on_case_sync` Site Setting allows cases to be created/synce without contacts.

This change introduces `salesforce_default_contact_id_for_case_sync` Site Setting for configuring a given Salesforce Contact as default Contact for use during case sync when `salesforce_skip_contact_creation_on_case_sync`  is enabeld.