### PR TITLE
DEV: Allow Case payload modification via a plugin modifiers

### DIFF
--- a/app/models/salesforce/case.rb
+++ b/app/models/salesforce/case.rb
@@ -7,13 +7,6 @@ module ::Salesforce
     belongs_to :topic
 
     def generate!
-      payload = {
-        ContactId: self.contact_id,
-        Subject: self.subject,
-        Description: self.description,
-        Origin: SiteSetting.salesforce_case_origin,
-      }
-
       data = Salesforce::Api.new.post("sobjects/Case", payload)
 
       self.uid = data["id"]
@@ -82,6 +75,19 @@ module ::Salesforce
       else
         user.create_salesforce_contact
       end
+    end
+
+    private
+
+    def payload
+      default = {
+        ContactId: self.contact_id,
+        Subject: self.subject,
+        Description: self.description,
+        Origin: SiteSetting.salesforce_case_origin,
+      }
+
+      DiscoursePluginRegistry.apply_modifier(:salesforce_case_payload, default, topic)
     end
   end
 end


### PR DESCRIPTION
There is currently no way to sync custom fields for any of the Salesforce objects in this plugin.

This change allows for the Case request payload to be extended by other plugins to permit syncing of customer specific custom fields.