### PR TITLE
DEV: Add API logging and a user readable error when credentials are incorrect

### DIFF
--- a/app/controllers/salesforce/cases_controller.rb
+++ b/app/controllers/salesforce/cases_controller.rb
@@ -5,8 +5,13 @@ module Salesforce
     def sync
       params.require(:topic_id)
       topic = Topic.find(params[:topic_id])
-      salesforce_case = Case.sync!(topic)
-      render_serialized(salesforce_case, CaseSerializer)
+
+      begin
+        salesforce_case = Case.sync!(topic)
+        render_serialized(salesforce_case, CaseSerializer)
+      rescue Salesforce::InvalidCredentials
+        render json: { error: I18n.t("salesforce.error.invalid_client_credentials") }, status: 502
+      end
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -18,7 +18,7 @@ en:
   salesforce:
     error:
       invalid_response: "Invalid response from Salesforce API"
-      invalid_client_credentials: "Invalid Salesforce credentials. Please inform your site admin to confirm the validity of the Salesforce client id and client secret settings"
+      invalid_client_credentials: "There was an issue with the Salesforce credentials. Please confirm the validity of the Salesforce client id and client secret settings"
   dashboard:
     salesforce:
       app_not_approved: "The Discourse connected app is not yet authorized in Salesforce by the user mentioned in site setting `salesforce_username`. Please follow <a href='%{base_url}/salesforce/admin/authorize'>this link</a> to authorize it."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -18,6 +18,7 @@ en:
   salesforce:
     error:
       invalid_response: "Invalid response from Salesforce API"
+      invalid_client_credentials: "Invalid Salesforce credentials. Please inform your site admin to confirm the validity of the Salesforce client id and client secret settings"
   dashboard:
     salesforce:
       app_not_approved: "The Discourse connected app is not yet authorized in Salesforce by the user mentioned in site setting `salesforce_username`. Please follow <a href='%{base_url}/salesforce/admin/authorize'>this link</a> to authorize it."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,3 +47,6 @@ plugins:
     default: false
   salesforce_default_contact_id_for_case_sync:
     default: ""
+  salesforce_api_error_logs:
+    default: false
+    hidden: true

--- a/lib/salesforce/api.rb
+++ b/lib/salesforce/api.rb
@@ -80,6 +80,9 @@ module ::Salesforce
       if status == 400 && body.include?("user hasn't approved this consumer")
         AdminDashboardData.add_problem_message(APP_NOT_APPROVED)
       end
+      if status >= 300 && SiteSetting.salesforce_api_error_logs
+        Rails.logger.error("Salesforce API error: #{status} #{body}")
+      end
       raise Salesforce::InvalidCredentials if status != 200
 
       data = JSON.parse(body)

--- a/spec/requests/cases_controller_spec.rb
+++ b/spec/requests/cases_controller_spec.rb
@@ -38,5 +38,21 @@ RSpec.describe ::Salesforce::CasesController do
       expect(salesforce_case.number).to eq("345678")
       expect(salesforce_case.status).to eq("New")
     end
+
+    it "shows a user readable error when credentials are invalid" do
+      sign_in(admin)
+      Salesforce.seed_groups!
+
+      stub_request(:post, "https://login.salesforce.com/services/oauth2/token").to_return(
+        status: 300,
+      )
+
+      post "/salesforce/cases/sync.json", params: { topic_id: topic.id }
+
+      expect(response.status).to eq(502)
+      expect(JSON.parse(response.body)).to eq(
+        { "error" => I18n.t("salesforce.error.invalid_client_credentials") },
+      )
+    end
   end
 end


### PR DESCRIPTION

https://github.com/discourse/discourse-salesforce/assets/1555215/1e43f6b2-8a1c-4eef-9f08-4937446c1d15

There's another issue where the loading spinner doesn't end, but we'll fix that later.