### PR TITLE
DEV: Prevent sync jobs from failing if API keys are wrong

### DIFF
--- a/app/jobs/scheduled/sync_salesforce_users.rb
+++ b/app/jobs/scheduled/sync_salesforce_users.rb
@@ -8,7 +8,12 @@ module ::Jobs
     def execute(args)
       return unless SiteSetting.salesforce_enabled
 
-      api_client = Salesforce::Api.new
+      begin
+        api_client = Salesforce::Api.new
+      rescue Salesforce::InvalidCredentials
+        return
+      end
+
       lead_fields = UserCustomField.where(name: ::Salesforce::Lead::ID_FIELD)
       lead_fields.find_in_batches(batch_size: 100) do |fields|
         ids = fields.pluck(:value)

--- a/spec/jobs/sync_salesforce_users_spec.rb
+++ b/spec/jobs/sync_salesforce_users_spec.rb
@@ -8,32 +8,45 @@ RSpec.describe Jobs::SyncSalesforceUsers do
 
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
+  let!(:path) { api_path.sub("sobjects", "composite/sobjects") }
 
-  before do
-    user1.salesforce_lead_id = "lead_123"
-    user1.save!
+  describe "proper leads and contacts in response" do
+    before do
+      user1.salesforce_lead_id = "lead_123"
+      user1.save!
 
-    user2.salesforce_contact_id = "contact_123"
-    user2.save!
+      user2.salesforce_contact_id = "contact_123"
+      user2.save!
 
-    path = api_path.sub("sobjects", "composite/sobjects")
-    stub_request(:get, "#{path}/Lead?fields=ConvertedContactId&ids=lead_123").to_return(
-      status: 200,
-      body: [{ ConvertedContactId: "contact_456", Id: "lead_123" }].to_json,
-    )
-    stub_request(
-      :get,
-      "#{path}/Contact?fields=MasterRecordId&ids=contact_456,contact_123",
-    ).to_return(status: 200, body: [{ MasterRecordId: "contact_789", Id: "contact_123" }].to_json)
+      stub_request(:get, "#{path}/Lead?fields=ConvertedContactId&ids=lead_123").to_return(
+        status: 200,
+        body: [{ ConvertedContactId: "contact_456", Id: "lead_123" }].to_json,
+      )
+      stub_request(
+        :get,
+        "#{path}/Contact?fields=MasterRecordId&ids=contact_456,contact_123",
+      ).to_return(status: 200, body: [{ MasterRecordId: "contact_789", Id: "contact_123" }].to_json)
+    end
+
+    it "syncs lead to contact conversions and contact merges from Salesforce" do
+      described_class.new.execute({})
+
+      fields = user1.reload.custom_fields
+      expect(fields[::Salesforce::Lead::ID_FIELD]).to eq(nil)
+      expect(fields[::Salesforce::Contact::ID_FIELD]).to eq("contact_456")
+
+      expect(user2.reload.salesforce_contact_id).to eq("contact_789")
+    end
   end
 
-  it "syncs lead to contact conversions and contact merges from Salesforce" do
-    described_class.new.execute({})
+  describe "bad response" do
+    it "does not fail the job" do
+      stub_request(
+        :post,
+        "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/token",
+      ).to_return(status: 400)
 
-    fields = user1.reload.custom_fields
-    expect(fields[::Salesforce::Lead::ID_FIELD]).to eq(nil)
-    expect(fields[::Salesforce::Contact::ID_FIELD]).to eq("contact_456")
-
-    expect(user2.reload.salesforce_contact_id).to eq("contact_789")
+      expect { described_class.new.execute({}) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
Right now when the credentials are wrong, getting the access token during the sync job fails the job.

This prevents the job from failing. 

This credential error is currently properly shown to the user when the user is trying to create a new lead.