### PR TITLE
DEV: Change settings root from plugins: to discourse_salesforce

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_salesforce: "Discourse Salesforce"
   js:
     login:
       salesforce:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_salesforce:
   salesforce_enabled:
     default: false
   salesforce_login_enabled:


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.