### PR TITLE
FIX: don't sync new user if API credentials are not available.

### DIFF
--- a/lib/salesforce/api.rb
+++ b/lib/salesforce/api.rb
@@ -57,6 +57,8 @@ module ::Salesforce
     end
 
     def set_access_token
+      raise Salesforce::InvalidCredentials unless self.class.has_credentials?
+
       if AdminDashboardData.problem_message_check(APP_NOT_APPROVED)
         AdminDashboardData.clear_problem_message(APP_NOT_APPROVED)
       end
@@ -110,6 +112,12 @@ module ::Salesforce
 
     def jwt_assertion
       JWT.encode(claims, private_key, "RS256")
+    end
+
+    def self.has_credentials?
+      SiteSetting.salesforce_client_id.present? && SiteSetting.salesforce_username.present? &&
+        SiteSetting.salesforce_rsa_private_key.present? &&
+        SiteSetting.salesforce_authorization_server_url.present?
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -116,10 +116,12 @@ after_initialize do
   Search.preloaded_topic_custom_fields << ::CaseMixin::HAS_SALESFORCE_CASE
 
   on(:user_created) do |user, opts|
-    if user.salesforce_contact_id = ::Salesforce::Contact.find_id_by_email(user.email)
-      user.save_custom_fields
-    elsif user.salesforce_lead_id = ::Salesforce::Lead.find_id_by_email(user.email)
-      user.save_custom_fields
+    if ::Salesforce::Api.has_credentials?
+      if user.salesforce_contact_id = ::Salesforce::Contact.find_id_by_email(user.email)
+        user.save_custom_fields
+      elsif user.salesforce_lead_id = ::Salesforce::Lead.find_id_by_email(user.email)
+        user.save_custom_fields
+      end
     end
   end
 

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -11,4 +11,9 @@ RSpec.describe ::Salesforce::Api do
     expect(SiteSetting.salesforce_instance_url).to eq(instance_url)
     expect(api.access_token).to eq(access_token)
   end
+
+  it "returns invalid credentials error when Salesforce client ID is blank" do
+    SiteSetting.salesforce_client_id = ""
+    expect { described_class.new }.to raise_error(::Salesforce::InvalidCredentials)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ RSpec.shared_context "with salesforce spec helper" do
   before do
     SiteSetting.salesforce_enabled = true
     SiteSetting.salesforce_client_id = "SALESFORCE_CLIENT_ID"
+    SiteSetting.salesforce_username = "SALESFORCE_API_USERNAME"
+    SiteSetting.salesforce_rsa_private_key = "SALESFORCE_PRIVATE_KEY"
+
     Salesforce::Api.any_instance.stubs(:jwt_assertion).returns("SALESFORCE_PRIVATE_KEY")
     stub_request(:post, "https://login.salesforce.com/services/oauth2/token").with(
       body: {


### PR DESCRIPTION
On `user_created` event we should check whether we have API credentials or not before performing the sync with Salesforce.