### PR TITLE
FIX: uses new addPostAdminMenuButton api

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.2.0.beta2-dev: 279af22bccf5c5b8832ba84a06e8c0ead77c95e1
 3.1.999: b6eb5ed5438b6d6336c2b167a537b4b6eadba2c2
 

--- a/assets/javascripts/discourse/initializers/extend-for-salesforce.js
+++ b/assets/javascripts/discourse/initializers/extend-for-salesforce.js
@@ -78,7 +78,7 @@ function initializeWithApi(api, container) {
     const siteSettings = container.lookup("site-settings:main");
     const salesforceUrl = siteSettings.salesforce_instance_url;
 
-    api.addPostAdminMenuButton((attrs) => {
+    api.addPostAdminMenuButton(() => {
       return {
         icon: "user-plus",
         label: "salesforce.lead.create",
@@ -90,7 +90,7 @@ function initializeWithApi(api, container) {
       };
     });
 
-    api.addPostAdminMenuButton((attrs) => {
+    api.addPostAdminMenuButton(() => {
       return {
         icon: "address-card",
         label: "salesforce.contact.create",

--- a/assets/javascripts/discourse/initializers/extend-for-salesforce.js
+++ b/assets/javascripts/discourse/initializers/extend-for-salesforce.js
@@ -10,26 +10,18 @@ import discourseComputed from "discourse-common/utils/decorators";
 
 const PLUGIN_ID = "discourse-salesforce";
 
-function createPerson(type, context) {
-  const post = context.model;
+async function createPerson(type, post) {
   post.set("flair_url", "loading spinner");
-  ajax(`/salesforce/persons/create`, {
-    type: "POST",
-    data: { type, user_id: post.user_id },
-  })
-    .catch(popupAjaxError)
-    .then(() => {
-      post.set("flair_url", "fab-salesforce");
-      context.appEvents.trigger("post-stream:refresh", { id: post.id });
+
+  try {
+    await ajax(`/salesforce/persons/create`, {
+      type: "POST",
+      data: { type, user_id: post.user_id },
     });
-}
-
-function createLead() {
-  createPerson("lead", this);
-}
-
-function createContact() {
-  createPerson("contact", this);
+    post.set("flair_url", "fab-salesforce");
+  } catch (error) {
+    popupAjaxError(error);
+  }
 }
 
 function syncCaseForTopic(context) {
@@ -59,6 +51,7 @@ function syncCaseForTopic(context) {
 function initializeWithApi(api, container) {
   const currentUser = api.getCurrentUser();
   const isStaff = currentUser?.staff;
+  const appEvents = container.lookup("service:app-events");
 
   if (isStaff) {
     api.modifyClass("raw-view:topic-status", {
@@ -85,34 +78,29 @@ function initializeWithApi(api, container) {
     const siteSettings = container.lookup("site-settings:main");
     const salesforceUrl = siteSettings.salesforce_instance_url;
 
-    api.decorateWidget("post-admin-menu:after", (dec) => {
-      return dec.h(
-        "ul",
-        dec.attach("post-admin-menu-button", {
-          icon: "user-plus",
-          label: "salesforce.lead.create",
-          action: "createLead",
-          secondaryAction: "closeAdminMenu",
-          className: "create-lead",
-        })
-      );
+    api.addPostAdminMenuButton((attrs) => {
+      return {
+        icon: "user-plus",
+        label: "salesforce.lead.create",
+        action: async (post) => {
+          await createPerson("lead", post);
+          appEvents.trigger("post-stream:refresh", { id: post.id });
+        },
+        className: "create-lead",
+      };
     });
 
-    api.decorateWidget("post-admin-menu:after", (dec) => {
-      return dec.h(
-        "ul",
-        dec.attach("post-admin-menu-button", {
-          icon: "address-card",
-          label: "salesforce.contact.create",
-          action: "createContact",
-          secondaryAction: "closeAdminMenu",
-          className: "create-contact",
-        })
-      );
+    api.addPostAdminMenuButton((attrs) => {
+      return {
+        icon: "address-card",
+        label: "salesforce.contact.create",
+        action: async (post) => {
+          await createPerson("contact", post);
+          appEvents.trigger("post-stream:refresh", { id: post.id });
+        },
+        className: "create-contact",
+      };
     });
-
-    api.attachWidgetAction("post", "createLead", createLead);
-    api.attachWidgetAction("post", "createContact", createContact);
 
     api.addPosterIcon((cfs) => {
       if (cfs.salesforce_lead_id) {


### PR DESCRIPTION
It's been broken since float kit has been introduced, this should now correctly show the buttons in the post admin menu.

![Screenshot 2023-11-27 at 11 18 30](https://github.com/discourse/discourse-salesforce/assets/339945/873702e6-d7f6-48e0-87ad-1dac004ab7b6)
