### PR TITLE
FIX: move Salesforce API calls to background job.

### DIFF
--- a/app/jobs/regular/sync_salesforce_user.rb
+++ b/app/jobs/regular/sync_salesforce_user.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ::Jobs
+  class SyncSalesforceUser < ::Jobs::Base
+    def execute(args)
+      return unless SiteSetting.salesforce_enabled
+
+      user = User.find(args[:user_id])
+      if user.salesforce_contact_id = ::Salesforce::Contact.find_id_by_email(user.email)
+        user.save_custom_fields
+      elsif user.salesforce_lead_id = ::Salesforce::Lead.find_id_by_email(user.email)
+        user.save_custom_fields
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../spec_helper"
+
+RSpec.describe User do
+  include_context "with salesforce spec helper"
+
+  describe "#on_create" do
+    it "syncs user to Salesforce" do
+      user = Fabricate.build(:user)
+      user.save!
+
+      job_args = Jobs::SyncSalesforceUser.jobs.last["args"].first
+      expect(job_args["user_id"]).to eq(user.id)
+    end
+  end
+end


### PR DESCRIPTION
Otherwise, it will show an error in the signup form even after the user is created when the API call fails. This commit adds a new job `SyncSalesforceUser` that is responsible for syncing Salesforce user information. The job checks if Salesforce integration is enabled and then retrieves the user's Salesforce contact or lead ID based on their email. If a match is found, the user's custom fields are saved.