### PR TITLE
FIX: Add Rails 7+ compatibility

### DIFF
--- a/app/controllers/salesforce/admin_controller.rb
+++ b/app/controllers/salesforce/admin_controller.rb
@@ -7,7 +7,8 @@ module Salesforce
     skip_before_action :check_xhr, :preload_json
 
     def authorize
-      redirect_to "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/authorize?client_id=#{SiteSetting.salesforce_client_id}&redirect_uri=#{Discourse.base_url}&response_type=code"
+      redirect_to "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/authorize?client_id=#{SiteSetting.salesforce_client_id}&redirect_uri=#{Discourse.base_url}&response_type=code",
+                  allow_other_host: true
     end
   end
 end

--- a/spec/requests/admin_controller_spec.rb
+++ b/spec/requests/admin_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../spec_helper"
+
+RSpec.describe ::Salesforce::AdminController do
+  include_context "with salesforce spec helper"
+
+  fab!(:admin)
+
+  describe "#authorize" do
+    before { sign_in(admin) }
+
+    it "redirects to the Salesforce authorization server" do
+      get "/salesforce/admin/authorize"
+      expect(response).to redirect_to(
+        "https://login.salesforce.com/services/oauth2/authorize?client_id=SALESFORCE_CLIENT_ID&redirect_uri=#{Discourse.base_url}&response_type=code",
+      )
+    end
+  end
+end


### PR DESCRIPTION
When redirecting to an external URL with Rails 7+, the `allow_other_host` option is needed.