### PR TITLE
FIX: Remove incorrectly added 'App not approved' message

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -32,8 +32,6 @@ after_initialize do
   SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-salesforce", "db", "fixtures").to_s
   register_problem_check Salesforce::ProblemCheck::SalesforceInvalidCredentials
 
-  AdminDashboardData.problem_messages << ::Salesforce::Api::APP_NOT_APPROVED
-
   allow_staff_user_custom_field(::Salesforce::Contact::ID_FIELD)
   allow_staff_user_custom_field(::Salesforce::Lead::ID_FIELD)
   register_topic_custom_field_type(::CaseMixin::HAS_SALESFORCE_CASE, :boolean)


### PR DESCRIPTION
It looks like it is added all the time despite the app being approved. Removing this first to prevent confusion

<img width="520" alt="Screenshot 2024-09-03 at 4 25 30 PM" src="https://github.com/user-attachments/assets/af34c5ca-bebb-4e05-9cbf-8c80deeb7046">
