### PR TITLE
FIX: Use correct user_id field from return auth result

### DIFF
--- a/db/migrate/20240904035546_update_salesforce_oauth_provider_uid.rb
+++ b/db/migrate/20240904035546_update_salesforce_oauth_provider_uid.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UpdateSalesforceOauthProviderUid < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL.squish
+      UPDATE user_associated_accounts
+      SET provider_uid = REGEXP_REPLACE(provider_uid, '^https://login\\.salesforce\\.com/id/[^/]+/', '')
+      WHERE provider_name = 'salesforce';
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -123,7 +123,7 @@ class OmniAuth::Strategies::Salesforce < OmniAuth::Strategies::OAuth2
     super
   end
 
-  uid { raw_info["id"] }
+  uid { raw_info["user_id"] }
 
   info do
     {

--- a/spec/models/user_associated_account_provider_uid_spec.rb
+++ b/spec/models/user_associated_account_provider_uid_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../../db/migrate/20240904035546_update_salesforce_oauth_provider_uid.rb"
+
+RSpec.describe "UpdateSalesforceOauthProviderUid" do
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+
+  it "properly updates the uid" do
+    salesforce1 =
+      UserAssociatedAccount.create(
+        user_id: user1.id,
+        provider_uid: "https://login.salesforce.com/id/00D5Y000001cLNoUAM/0055Y00000F77E3QAJ",
+        provider_name: "salesforce",
+      )
+    salesforce2 =
+      UserAssociatedAccount.create(
+        user_id: user2.id,
+        provider_uid: "abcdxyz",
+        provider_name: "salesforce",
+      )
+    not_salesforce =
+      UserAssociatedAccount.create(
+        user_id: user1.id,
+        provider_uid: "https://login.salesforce.com/id/00D5Y000001cLNoUAM/0055Y00000F77E3QAJ",
+        provider_name: "not_salesforce",
+      )
+
+    UpdateSalesforceOauthProviderUid.new.up
+
+    expect(salesforce1.reload.provider_uid).to eq("0055Y00000F77E3QAJ")
+    expect(salesforce2.reload.provider_uid).to eq("abcdxyz")
+    expect(not_salesforce.reload.provider_uid).to eq(
+      "https://login.salesforce.com/id/00D5Y000001cLNoUAM/0055Y00000F77E3QAJ",
+    )
+  end
+end


### PR DESCRIPTION
We are currently using the wrong oauth result field `id` instead of `user_id`. This means the provider_uid looks something like
`https://login.salesforce.com/id/<organisation-id>/<provider-uid>` now but it should be `<provider-uid>` instead.

This requires a migration as well. There is a test but can be removed once this PR is approved. One can refer to https://demo.discourse.group/t/troubleshooting-salesforce-auth/33 on an example payload.