### PR TITLE
DEV: Log credentials error from SyncSalesforceUsers job 

### DIFF
--- a/app/jobs/scheduled/sync_salesforce_users.rb
+++ b/app/jobs/scheduled/sync_salesforce_users.rb
@@ -11,6 +11,9 @@ module ::Jobs
       begin
         api_client = Salesforce::Api.new
       rescue Salesforce::InvalidCredentials
+        if SiteSetting.salesforce_api_error_logs
+          Rails.logger.error("SyncSalesforceUsers Job Error: Invalid credentials")
+        end
         return
       end
 

--- a/spec/jobs/sync_salesforce_users_spec.rb
+++ b/spec/jobs/sync_salesforce_users_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Jobs::SyncSalesforceUsers do
 
       after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
-      it "logs an invalid credentials error job fails with 401" do
+      it "logs the error" do
         stub_request(
           :post,
           "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/token",

--- a/spec/jobs/sync_salesforce_users_spec.rb
+++ b/spec/jobs/sync_salesforce_users_spec.rb
@@ -40,13 +40,35 @@ RSpec.describe Jobs::SyncSalesforceUsers do
   end
 
   describe "bad response" do
-    it "does not fail the job" do
+    it "does not fail the job with a 400 error" do
       stub_request(
         :post,
         "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/token",
       ).to_return(status: 400)
 
       expect { described_class.new.execute({}) }.not_to raise_error
+    end
+
+    context "with `salesforce_api_error_logs` enabled" do
+      let(:fake_logger) { FakeLogger.new }
+
+      before do
+        SiteSetting.salesforce_api_error_logs = true
+        Rails.logger.broadcast_to(fake_logger)
+      end
+
+      after { Rails.logger.stop_broadcasting_to(fake_logger) }
+
+      it "logs an invalid credentials error job fails with 401" do
+        stub_request(
+          :post,
+          "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/token",
+        ).to_return(status: 401)
+
+        described_class.new.execute({})
+
+        expect(fake_logger.errors.last).to eq("SyncSalesforceUsers Job Error: Invalid credentials")
+      end
     end
   end
 end


### PR DESCRIPTION
We have an existing site setting for logging API errors. Using it to log an error syncing users.