### PR TITLE
REVERT: "DEV: Log credentials error from SyncSalesforceUsers job  (#111)"

### DIFF
--- a/app/jobs/scheduled/sync_salesforce_users.rb
+++ b/app/jobs/scheduled/sync_salesforce_users.rb
@@ -11,9 +11,6 @@ module ::Jobs
       begin
         api_client = Salesforce::Api.new
       rescue Salesforce::InvalidCredentials
-        if SiteSetting.salesforce_api_error_logs
-          Rails.logger.error("SyncSalesforceUsers Job Error: Invalid credentials")
-        end
         return
       end
 

--- a/spec/jobs/sync_salesforce_users_spec.rb
+++ b/spec/jobs/sync_salesforce_users_spec.rb
@@ -40,35 +40,13 @@ RSpec.describe Jobs::SyncSalesforceUsers do
   end
 
   describe "bad response" do
-    it "does not fail the job with a 400 error" do
+    it "does not fail the job" do
       stub_request(
         :post,
         "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/token",
       ).to_return(status: 400)
 
       expect { described_class.new.execute({}) }.not_to raise_error
-    end
-
-    context "with `salesforce_api_error_logs` enabled" do
-      let(:fake_logger) { FakeLogger.new }
-
-      before do
-        SiteSetting.salesforce_api_error_logs = true
-        Rails.logger.broadcast_to(fake_logger)
-      end
-
-      after { Rails.logger.stop_broadcasting_to(fake_logger) }
-
-      it "logs the error" do
-        stub_request(
-          :post,
-          "#{SiteSetting.salesforce_authorization_server_url}/services/oauth2/token",
-        ).to_return(status: 401)
-
-        described_class.new.execute({})
-
-        expect(fake_logger.errors.last).to eq("SyncSalesforceUsers Job Error: Invalid credentials")
-      end
     end
   end
 end


### PR DESCRIPTION
This reverts commit 5f67c9f7b2e825a115f4174f8ff8fc8ed45cd4df.

It wasn't necessary. This added a double-log. I had thought we weren't logging an error, when we actually were :) 

Proof:
<img width="1616" alt="Screenshot 2025-03-06 at 3 16 34 PM" src="https://github.com/user-attachments/assets/b19ba31a-a0c2-4485-9251-b72010687f0f" />
