### PR TITLE
DEV: Replace deprecated add_problem_message with inline problem check

### DIFF
--- a/app/services/salesforce/problem_check/salesforce_app_not_approved.rb
+++ b/app/services/salesforce/problem_check/salesforce_app_not_approved.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Salesforce::ProblemCheck::SalesforceAppNotApproved < ProblemCheck::InlineProblemCheck
+  self.priority = "high"
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -21,7 +21,6 @@ en:
       invalid_response: "Invalid response from Salesforce API"
       invalid_client_credentials: "There was an issue with the Salesforce credentials. Please confirm the validity of the Salesforce client id and client secret settings"
   dashboard:
-    salesforce:
-      app_not_approved: "The Discourse connected app is not yet authorized in Salesforce by the user mentioned in site setting `salesforce_username`. Please follow <a href='%{base_url}/salesforce/admin/authorize'>this link</a> to authorize it."
     problem:
       salesforce_invalid_credentials: "There was an issue with the Salesforce credentials. Please confirm the validity of the Salesforce client id and client secret settings"
+      salesforce_app_not_approved: "The Discourse connected app is not yet authorized in Salesforce by the user mentioned in site setting `salesforce_username`. Please follow <a href='%{base_path}/salesforce/admin/authorize'>this link</a> to authorize it."

--- a/plugin.rb
+++ b/plugin.rb
@@ -31,6 +31,7 @@ require_relative "lib/validators/salesforce_login_enabled_validator"
 after_initialize do
   SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-salesforce", "db", "fixtures").to_s
   register_problem_check Salesforce::ProblemCheck::SalesforceInvalidCredentials
+  register_problem_check Salesforce::ProblemCheck::SalesforceAppNotApproved
 
   allow_staff_user_custom_field(::Salesforce::Contact::ID_FIELD)
   allow_staff_user_custom_field(::Salesforce::Lead::ID_FIELD)

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -19,17 +19,36 @@ RSpec.describe ::Salesforce::Api do
 
     problem = AdminNotice.find_by(identifier: "salesforce_invalid_credentials")
     expect(problem.message).to eq(
-      I18n.t("dashboard.problem.salesforce_invalid_credentials", base_path: Discourse.base_path),
+      I18n.t("dashboard.problem.salesforce_invalid_credentials"),
     )
     expect(ProblemCheckTracker["salesforce_invalid_credentials"].failing?).to eq(true)
+  end
+
+  context "when app is not approved" do
+    let(:api_response_status) { 400 }
+    let(:api_response_body) { "user hasn't approved this consumer" }
+
+    it "creates an admin notice if the app is not approved" do
+      SiteSetting.salesforce_client_id = "client_id"
+
+      expect { described_class.new }.to raise_error(::Salesforce::InvalidCredentials)
+
+      problem = AdminNotice.find_by(identifier: "salesforce_app_not_approved")
+      expect(problem.message).to eq(
+        I18n.t("dashboard.problem.salesforce_app_not_approved", base_path: Discourse.base_path),
+      )
+      expect(ProblemCheckTracker["salesforce_app_not_approved"].failing?).to eq(true)
+    end
   end
 
   it "resets invalid credentials error when Salesforce client ID is present" do
     SiteSetting.salesforce_client_id = "client_id"
     ProblemCheckTracker["salesforce_invalid_credentials"].problem!
+    ProblemCheckTracker["salesforce_app_not_approved"].problem!
 
     described_class.new
 
     expect(ProblemCheckTracker["salesforce_invalid_credentials"].failing?).to eq(false)
+    expect(ProblemCheckTracker["salesforce_app_not_approved"].failing?).to eq(false)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 RSpec.shared_context "with salesforce spec helper" do
   let(:access_token) { "SALESFORCE_ACCESS_TOKEN" }
   let(:instance_url) { "https://test.my.salesforce.com/" }
+  let(:api_response_status) { 200 }
+  let(:api_response_body) { %({"access_token":"#{access_token}","instance_url":"#{instance_url}"}) }
 
   before do
     SiteSetting.salesforce_enabled = true
@@ -17,8 +19,8 @@ RSpec.shared_context "with salesforce spec helper" do
         "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer",
       },
     ).to_return(
-      status: 200,
-      body: %({"access_token":"#{access_token}","instance_url":"#{instance_url}"}),
+      status: api_response_status,
+      body: api_response_body,
       headers: {
       },
     )


### PR DESCRIPTION
### What is this change?

`AdminDashboardData#add_problem_message` used to allow setting an arbitrary admin notice in the old problem check system. With the introduction of the new system, this is handled by inline problem checks.

This PR replaces the former with the latter.