### PR TITLE
DEV: Remove redundant `post-stream:refresh` event triggers

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-salesforce.js
+++ b/assets/javascripts/discourse/initializers/extend-for-salesforce.js
@@ -38,8 +38,6 @@ function initializeWithApi(api, container) {
         label: "salesforce.lead.create",
         action: async (post) => {
           await createPerson("lead", post);
-          // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
-          appEvents.trigger("post-stream:refresh", { id: post.id });
         },
         className: "create-lead",
       };
@@ -51,8 +49,6 @@ function initializeWithApi(api, container) {
         label: "salesforce.contact.create",
         action: async (post) => {
           await createPerson("contact", post);
-          // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
-          appEvents.trigger("post-stream:refresh", { id: post.id });
         },
         className: "create-contact",
       };
@@ -99,11 +95,6 @@ function initializeWithApi(api, container) {
 
             topic.salesforce_case_loading = true;
 
-            // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
-            _appEvents.trigger("post-stream:refresh", {
-              id: op.id,
-            });
-
             try {
               const data = await ajax(`/salesforce/cases/sync`, {
                 type: "POST",
@@ -114,11 +105,6 @@ function initializeWithApi(api, container) {
               popupAjaxError(error);
             } finally {
               topic.salesforce_case_loading = false;
-
-              // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
-              _appEvents.trigger("post-stream:refresh", {
-                id: op.id,
-              });
             }
           },
         };


### PR DESCRIPTION
Eliminate obsolete `post-stream:refresh` event triggers. These events were marked as TODO for removal after the Glimmer migration and are no longer needed.

This cleanup improves code clarity and reduces unnecessary event emissions, with no impact on functionality since the events were unused by the current post-stream implementation.