### PR TITLE
FIX: Avoid stale Salesforce case status after sync

### DIFF
--- a/lib/salesforce/topic_extension.rb
+++ b/lib/salesforce/topic_extension.rb
@@ -5,8 +5,6 @@ module Salesforce
     extend ActiveSupport::Concern
 
     def has_salesforce_case
-      return @has_salesforce_case if defined?(@has_salesforce_case)
-
       field = CaseMixin::HAS_SALESFORCE_CASE
       value =
         if custom_field_preloaded?(field)
@@ -17,7 +15,7 @@ module Salesforce
           custom_fields[field]
         end
 
-      @has_salesforce_case = ActiveModel::Type::Boolean.new.cast(value)
+      ActiveModel::Type::Boolean.new.cast(value) ? true : false
     end
 
     def salesforce_case

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -101,6 +101,21 @@ RSpec.describe Salesforce::Case do
         expect(topic.user.salesforce_contact_id).to eq("123456")
       end
 
+      it "uses an existing salesforce contact when one matches the topic user email" do
+        stub_salesforce_person_lookup("Contact", topic.user.email, id: "existing_contact_id")
+
+        stub_request(:post, "#{api_path}/Case").with(
+          body:
+            %({"ContactId":"existing_contact_id","Subject":"#{topic.title}","Description":"#{post.full_url}\\n\\n#{post.raw}","Origin":"Web"}),
+        ).to_return(status: 200, body: %({"id":"234567"}), headers: {})
+
+        expect do ::Salesforce::Case.sync!(topic) end.to change { ::Salesforce::Case.count }.by(1)
+
+        expect(topic.user.salesforce_contact_id).to eq("existing_contact_id")
+        expect(Salesforce.contacts_group.users.exists?(topic.user.id)).to eq(true)
+        expect(a_request(:post, "#{api_path}/Contact")).not_to have_been_made
+      end
+
       include_examples "existing contact"
     end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,5 +16,17 @@ describe Topic do
 
       expect(topic.has_salesforce_case).to eq(true)
     end
+
+    it "reflects changes to the case marker on the same topic instance" do
+      topic.custom_fields.delete(CaseMixin::HAS_SALESFORCE_CASE)
+      topic.save_custom_fields
+
+      expect(topic.has_salesforce_case).to eq(false)
+
+      topic.custom_fields[CaseMixin::HAS_SALESFORCE_CASE] = true
+      topic.save_custom_fields
+
+      expect(topic.has_salesforce_case).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
A topic could keep reporting that it did not have a Salesforce case after Case sync updated the  custom field on the same  instance.

In this PR, we stop memoizing , so the topic reflects the updated case marker immediately. It also adds regression coverage for Case sync using an existing Salesforce Contact found by email (previous PR).