### PR TITLE
FIX: Sync contacts/leads even if they already exist in SFDC and show a toast indicating so [backport 2026.6]

### DIFF
--- a/app/controllers/salesforce/cases_controller.rb
+++ b/app/controllers/salesforce/cases_controller.rb
@@ -16,6 +16,11 @@ module Salesforce
                  error: I18n.t("salesforce.error.invalid_client_credentials"),
                },
                status: :bad_gateway
+      rescue Salesforce::InvalidApiResponse => e
+        render json: {
+                 errors: [e.message.presence || I18n.t("salesforce.error.invalid_response")],
+               },
+               status: :unprocessable_content
       end
     end
   end

--- a/app/controllers/salesforce/persons_controller.rb
+++ b/app/controllers/salesforce/persons_controller.rb
@@ -5,14 +5,17 @@ module Salesforce
     requires_plugin PLUGIN_NAME
 
     before_action :find_user
-    attr_accessor :user
+    before_action :find_post
+    attr_accessor :user, :sync_post
 
     def create
       type = params.require(:type).capitalize
       raise ArgumentError.new :type if [Lead::OBJECT_NAME, Contact::OBJECT_NAME].exclude?(type)
 
       begin
-        "::Salesforce::#{type}".constantize.create!(user)
+        klass = "::Salesforce::#{type}".constantize
+        salesforce_id = klass.create!(user) || user.custom_fields[klass::ID_FIELD]
+        publish_person_synced(klass::ID_FIELD, salesforce_id)
         render json: success_json
       rescue => e
         render json: { errors: [e.message] }, status: :unprocessable_content
@@ -33,6 +36,25 @@ module Salesforce
       user_id = params[:user_id]
       @user = User.find_by(id: user_id)
       raise Discourse::InvalidParameters.new(:user_id) if user.blank?
+    end
+
+    def find_post
+      return if params[:post_id].blank?
+
+      @sync_post = Post.find_by(id: params[:post_id])
+      if sync_post.blank? || sync_post.user_id != user.id
+        raise Discourse::InvalidParameters.new(:post_id)
+      end
+    end
+
+    def publish_person_synced(field, value)
+      return if sync_post.blank? || value.blank?
+
+      MessageBus.publish(
+        "/topic/#{sync_post.topic_id}",
+        { type: "salesforce_person_synced", user_id: user.id, field: field, value: value },
+        group_ids: [Group::AUTO_GROUPS[:admins]],
+      )
     end
   end
 end

--- a/app/models/salesforce/person.rb
+++ b/app/models/salesforce/person.rb
@@ -8,8 +8,8 @@ module ::Salesforce
     def self.create!(user)
       return if user.custom_fields[self::ID_FIELD].present?
 
-      data = Salesforce::Api.new.post("sobjects/#{self::OBJECT_NAME}", payload(user))
-      id = data["id"]
+      id = find_id_by_email(user.email)
+      id ||= Salesforce::Api.new.post("sobjects/#{self::OBJECT_NAME}", payload(user))["id"]
 
       user.custom_fields[self::ID_FIELD] = id
       user.save_custom_fields
@@ -20,7 +20,9 @@ module ::Salesforce
     end
 
     def self.find_id_by_email(email)
-      result = Salesforce.api.query("SELECT Id FROM #{self::OBJECT_NAME} WHERE Email = '#{email}'")
+      escaped_email = escape_soql_string(email)
+      result =
+        Salesforce.api.query("SELECT Id FROM #{self::OBJECT_NAME} WHERE Email = '#{escaped_email}'")
       return if result["totalSize"] == 0
       result["records"][0]["Id"]
     end
@@ -34,6 +36,10 @@ module ::Salesforce
     end
 
     private
+
+    def self.escape_soql_string(value)
+      value.to_s.gsub(/['\\]/) { |character| "\\#{character}" }
+    end
 
     def self.not_implemented
       raise "Not implemented."

--- a/assets/javascripts/discourse/initializers/extend-for-salesforce.js
+++ b/assets/javascripts/discourse/initializers/extend-for-salesforce.js
@@ -5,15 +5,31 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { i18n } from "discourse-i18n";
 import PostSalesforceCase from "../components/post-salesforce-case";
 
-async function createPerson(type, post) {
+export function updateSalesforcePersonFields(topic, message) {
+  topic.postStream.posts.forEach((post) => {
+    if (post.user_id === message.user_id) {
+      post.user_custom_fields = {
+        ...(post.user_custom_fields || {}),
+        [message.field]: message.value,
+      };
+    }
+  });
+}
+
+async function createPerson(type, post, toasts) {
   post.set("flair_url", "loading spinner");
 
   try {
     await ajax(`/salesforce/persons/create`, {
       type: "POST",
-      data: { type, user_id: post.user_id },
+      data: { type, user_id: post.user_id, post_id: post.id },
     });
     post.set("flair_url", "fab-salesforce");
+    toasts.success({
+      data: {
+        message: i18n(`salesforce.${type}.create_success`),
+      },
+    });
   } catch (error) {
     popupAjaxError(error);
   }
@@ -25,6 +41,7 @@ function initializeWithApi(api, container) {
 
   if (isStaff) {
     const siteSettings = container.lookup("service:site-settings");
+    const toasts = container.lookup("service:toasts");
     const salesforceUrl = siteSettings.salesforce_instance_url;
 
     api.addPostAdminMenuButton(() => {
@@ -32,7 +49,7 @@ function initializeWithApi(api, container) {
         icon: "user-plus",
         label: "salesforce.lead.create",
         action: async (post) => {
-          await createPerson("lead", post);
+          await createPerson("lead", post, toasts);
         },
         className: "create-lead",
       };
@@ -43,7 +60,7 @@ function initializeWithApi(api, container) {
         icon: "address-card",
         label: "salesforce.contact.create",
         action: async (post) => {
-          await createPerson("contact", post);
+          await createPerson("contact", post, toasts);
         },
         className: "create-contact",
       };
@@ -70,6 +87,13 @@ function initializeWithApi(api, container) {
         };
       }
     });
+
+    api.registerCustomPostMessageCallback(
+      "salesforce_person_synced",
+      (controller, message) => {
+        updateSalesforcePersonFields(controller.model, message);
+      }
+    );
 
     customizePost(api, container);
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -13,8 +13,10 @@ en:
       title: Salesforce
       lead:
         create: "Create Lead"
+        create_success: "Salesforce lead synced"
       contact:
         create: "Create Contact"
+        create_success: "Salesforce contact synced"
       poster_icon:
         lead:
           title: "Salesforce Lead"

--- a/lib/salesforce/api.rb
+++ b/lib/salesforce/api.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "cgi"
 
 module ::Salesforce
   class InvalidApiResponse < ::StandardError
@@ -28,8 +29,7 @@ module ::Salesforce
     end
 
     def query(soql)
-      soql = URI::Parser.new.escape(soql.gsub(" ", "+"))
-      get("query/?q=#{soql}")
+      get("query/?q=#{CGI.escape(soql)}")
     end
 
     def get(path)

--- a/lib/salesforce/topic_extension.rb
+++ b/lib/salesforce/topic_extension.rb
@@ -5,7 +5,19 @@ module Salesforce
     extend ActiveSupport::Concern
 
     def has_salesforce_case
-      custom_fields["has_salesforce_case"] ? true : false
+      return @has_salesforce_case if defined?(@has_salesforce_case)
+
+      field = CaseMixin::HAS_SALESFORCE_CASE
+      value =
+        if custom_field_preloaded?(field)
+          custom_fields[field]
+        elsif custom_fields_preloaded?
+          _custom_fields.where(name: field).pick(:value)
+        else
+          custom_fields[field]
+        end
+
+      @has_salesforce_case = ActiveModel::Type::Boolean.new.cast(value)
     end
 
     def salesforce_case

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe ::Salesforce::Api do
     expect(api.access_token).to eq(access_token)
   end
 
+  it "escapes plus signs in SOQL query parameters" do
+    soql = "SELECT Id FROM Contact WHERE Email = 'team+salesforce-discourse-dev-ed@example.com'"
+
+    stub_request(:get, query_path).with(query: { q: soql }).to_return(
+      status: 200,
+      body: { totalSize: 0, records: [] }.to_json,
+      headers: {
+      },
+    )
+
+    described_class.new.query(soql)
+
+    expect(a_request(:get, query_path).with(query: { q: soql })).to have_been_made
+  end
+
   it "returns invalid credentials error when Salesforce client ID is blank" do
     SiteSetting.salesforce_client_id = ""
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe Salesforce::Case do
       before do
         SiteSetting.salesforce_skip_contact_creation_on_case_sync = false
 
+        stub_salesforce_person_lookup("Contact", topic.user.email)
+
         stub_request(:post, "#{api_path}/Contact").with(
           body: topic.user.salesforce_contact_payload.to_json,
         ).to_return(status: 200, body: %({"id":"123456"}), headers: {})

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Salesforce::Contact do
+  include_context "with salesforce spec helper"
+
+  describe ".find_id_by_email" do
+    it "escapes SOQL string values before querying by email" do
+      email = "team+salesforce.o'hara@example.com"
+      contact_id = "123456"
+
+      stub_request(:get, query_path).with(
+        query: {
+          q: "SELECT Id FROM Contact WHERE Email = 'team+salesforce.o\\'hara@example.com'",
+        },
+      ).to_return(
+        status: 200,
+        body: { totalSize: 1, records: [{ Id: contact_id }] }.to_json,
+        headers: {
+        },
+      )
+
+      expect(described_class.find_id_by_email(email)).to eq(contact_id)
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+describe Topic do
+  describe "#has_salesforce_case" do
+    fab!(:topic)
+
+    before do
+      topic.custom_fields[CaseMixin::HAS_SALESFORCE_CASE] = true
+      topic.save!
+    end
+
+    it "checks the case marker when other topic custom fields are preloaded" do
+      topic.reload.set_preloaded_custom_fields("another_field" => nil)
+
+      expect(topic.has_salesforce_case).to eq(true)
+    end
+  end
+end

--- a/spec/requests/cases_controller_spec.rb
+++ b/spec/requests/cases_controller_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe ::Salesforce::CasesController do
       sign_in(admin)
       Salesforce.seed_groups!
 
+      stub_salesforce_person_lookup("Contact", topic.user.email)
+
       stub_request(:post, "#{api_path}/Contact").with(
         body: topic.user.salesforce_contact_payload.to_json,
       ).to_return(status: 200, body: %({"id":"123456"}), headers: {})
@@ -36,6 +38,32 @@ RSpec.describe ::Salesforce::CasesController do
       salesforce_case = ::Salesforce::Case.last
       expect(salesforce_case.number).to eq("345678")
       expect(salesforce_case.status).to eq("New")
+    end
+
+    it "returns the Salesforce error when case creation is rejected" do
+      sign_in(admin)
+      Salesforce.seed_groups!
+
+      stub_salesforce_person_lookup("Contact", topic.user.email)
+
+      stub_request(:post, "#{api_path}/Contact").with(
+        body: topic.user.salesforce_contact_payload.to_json,
+      ).to_return(status: 200, body: %({"id":"123456"}), headers: {})
+
+      salesforce_error =
+        %([{"message":"Required fields are missing: [Subject]","errorCode":"REQUIRED_FIELD_MISSING"}])
+
+      stub_request(:post, "#{api_path}/Case").to_return(
+        status: 400,
+        body: salesforce_error,
+        headers: {
+        },
+      )
+
+      post "/salesforce/cases/sync.json", params: { topic_id: topic.id }
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body).to eq({ "errors" => [salesforce_error] })
     end
 
     it "shows a user readable error when credentials are invalid" do

--- a/spec/requests/persons_controller_spec.rb
+++ b/spec/requests/persons_controller_spec.rb
@@ -15,17 +15,69 @@ RSpec.describe ::Salesforce::PersonsController do
     end
 
     it "creates a new contact object in Salesforce" do
+      sync_post = Fabricate(:post, user: user)
+
+      stub_salesforce_person_lookup("Contact", user.email)
+
       stub_request(:post, "#{api_path}/Contact").with(
         body: user.salesforce_contact_payload.to_json,
       ).to_return(status: 200, body: %({"id":"123456"}), headers: {})
 
-      post "/salesforce/persons/create.json", params: { type: "contact", user_id: user.id }
+      messages =
+        MessageBus.track_publish("/topic/#{sync_post.topic_id}") do
+          post "/salesforce/persons/create.json",
+               params: {
+                 type: "contact",
+                 user_id: user.id,
+                 post_id: sync_post.id,
+               }
+        end
 
       expect(response.status).to eq(200)
       expect(user.salesforce_contact_id).to eq("123456")
+      expect(messages.size).to eq(1)
+      expect(messages.first.data).to eq(
+        type: "salesforce_person_synced",
+        user_id: user.id,
+        field: "salesforce_contact_id",
+        value: "123456",
+      )
+      expect(messages.first.group_ids).to eq([Group::AUTO_GROUPS[:admins]])
+    end
+
+    it "links an existing contact in Salesforce by email" do
+      existing_user = Fabricate(:user, email: "team+salesforce-discourse-dev-ed@example.com")
+      existing_contact_id = "123456"
+
+      stub_salesforce_person_lookup("Contact", existing_user.email, id: existing_contact_id)
+
+      post "/salesforce/persons/create.json", params: { type: "contact", user_id: existing_user.id }
+
+      expect(response.status).to eq(200)
+      expect(existing_user.reload.salesforce_contact_id).to eq(existing_contact_id)
+      expect(Salesforce.contacts_group.users.exists?(existing_user.id)).to eq(true)
+      expect(a_request(:post, "#{api_path}/Contact")).not_to have_been_made
+    end
+
+    it "does not publish a topic update without a post" do
+      stub_salesforce_person_lookup("Contact", user.email)
+
+      stub_request(:post, "#{api_path}/Contact").with(
+        body: user.salesforce_contact_payload.to_json,
+      ).to_return(status: 200, body: %({"id":"123456"}), headers: {})
+
+      messages =
+        MessageBus.track_publish do
+          post "/salesforce/persons/create.json", params: { type: "contact", user_id: user.id }
+        end
+
+      expect(response.status).to eq(200)
+      expect(messages.map(&:channel)).not_to include(a_string_matching(%r{\A/topic/}))
     end
 
     it "creates a new lead object in Salesforce" do
+      stub_salesforce_person_lookup("Lead", user.email)
+
       stub_request(:post, "#{api_path}/Lead").with(
         body: user.salesforce_lead_payload.to_json,
       ).to_return(status: 200, body: %({"id":"123456"}), headers: {})

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -11,9 +11,9 @@ describe TopicViewSerializer do
   fab!(:admin)
 
   it "includes Salesforce case details" do
-    topic_view = TopicView.new(topic.id, admin)
     topic.custom_fields["has_salesforce_case"] = true
     topic.save!
+    topic_view = TopicView.new(topic.id, admin)
 
     json = described_class.new(topic_view, scope: Guardian.new(admin), root: false).as_json
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ RSpec.shared_context "with salesforce spec helper" do
   let(:api_response_body) { %({"access_token":"#{access_token}","instance_url":"#{instance_url}"}) }
 
   before do
+    Salesforce.instance_variable_set(:@api, nil)
+    Discourse.redis.del("salesforce_access_token")
+
     SiteSetting.salesforce_enabled = true
     SiteSetting.salesforce_client_id = "SALESFORCE_CLIENT_ID"
     SiteSetting.salesforce_username = "SALESFORCE_API_USERNAME"
@@ -23,5 +26,24 @@ RSpec.shared_context "with salesforce spec helper" do
 
   def api_path
     "#{instance_url}services/data/v49.0/sobjects"
+  end
+
+  def query_path
+    "#{instance_url}services/data/v49.0/query/"
+  end
+
+  def stub_salesforce_person_lookup(object_name, email, id: nil)
+    records = id.present? ? [{ Id: id }] : []
+
+    stub_request(:get, query_path).with(
+      query: {
+        q: "SELECT Id FROM #{object_name} WHERE Email = '#{email}'",
+      },
+    ).to_return(
+      status: 200,
+      body: { totalSize: records.size, records: records }.to_json,
+      headers: {
+      },
+    )
   end
 end

--- a/test/javascripts/unit/extend-for-salesforce-test.js
+++ b/test/javascripts/unit/extend-for-salesforce-test.js
@@ -1,0 +1,31 @@
+import { module, test } from "qunit";
+import { updateSalesforcePersonFields } from "discourse/plugins/discourse-salesforce/discourse/initializers/extend-for-salesforce";
+
+module("Unit | Initializer | extend-for-salesforce", function () {
+  test("updates Salesforce user custom fields on matching loaded posts", function (assert) {
+    const topic = {
+      postStream: {
+        posts: [
+          { user_id: 1, user_custom_fields: { existing: "value" } },
+          { user_id: 2, user_custom_fields: { other: "value" } },
+          { user_id: 1 },
+        ],
+      },
+    };
+
+    updateSalesforcePersonFields(topic, {
+      user_id: 1,
+      field: "salesforce_contact_id",
+      value: "003123",
+    });
+
+    assert.deepEqual(
+      topic.postStream.posts.map((post) => post.user_custom_fields),
+      [
+        { existing: "value", salesforce_contact_id: "003123" },
+        { other: "value" },
+        { salesforce_contact_id: "003123" },
+      ]
+    );
+  });
+});


### PR DESCRIPTION
Backport of #147 to d-compat/2026.6.

---

This PR handles the age-old 500 error when a SFDC contact already exists and an admin is trying to create it from Discourse.

We change the flow a bit here:
1. looks up existing SFDC Contacts/Leads by email before creating a new one, so duplicate records are linked instead of raising the `DUPLICATES_DETECTED` error we know
2. escapes SOQL query params correctly, including emails with `+`. (due to team email)
3. saves the returned SFDC id into the user custom fields and adds the user to the matching Salesforce group
4. returns the SFDC error body for failed case syncs instead of throwing a 500
5. shows a success toast after creating or linking a Contact/Lead 🥳 
6. publishes an admin-only MessageBus update so loaded posts update their Salesforce flair without a page refresh (bulk of the diff) 🥳 🥳 

## before 

https://github.com/user-attachments/assets/287f07dd-eb31-4b8e-b493-6e2a461f2eac 

## after 

https://github.com/user-attachments/assets/8c5c973b-fb42-4712-8ae3-c446f01251b7
